### PR TITLE
Add employee and admin service desk portal template

### DIFF
--- a/ui/employee-admin-portal/.eslintrc.cjs
+++ b/ui/employee-admin-portal/.eslintrc.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended'
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  plugins: ['react', 'react-hooks'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn'
+  }
+};

--- a/ui/employee-admin-portal/README.md
+++ b/ui/employee-admin-portal/README.md
@@ -1,0 +1,57 @@
+# Employee & Admin Service Desk Portal
+
+A polished Vite + React + JavaScript template that showcases an admin and employee workspace for service desk operations. The UI takes inspiration from contemporary SaaS dashboards and comes with demo data powered by an in-memory API layer so the experience works end-to-end without additional setup.
+
+## Features
+
+- ⚡️ **Vite + React** with React Router and Context APIs for state management.
+- 🎨 **Bootstrap 5** & Bootstrap Icons for responsive layouts and a modern look.
+- 👨‍💼 **Admin panel** with dashboard analytics, ticket overview, and collapsible team management tree.
+- 👩‍💻 **Employee workspace** to review tickets and raise new requests from a guided form.
+- 🔐 **Role-specific authentication** flows with dedicated URLs:
+  - `/admin/auth/signin`
+  - `/employee/auth/signin`
+- 🔌 **Mock API client** that simulates authentication, ticketing, and team data, making it easy to replace with a real backend later.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server defaults to [http://localhost:5173](http://localhost:5173) and will automatically open in your browser.
+
+### Demo credentials
+
+Use the bundled demo accounts to explore both portals:
+
+| Role      | Email               | Password    |
+|-----------|---------------------|-------------|
+| Admin     | `admin@desk.com`    | `admin123`  |
+| Employee  | `employee@desk.com` | `employee123` |
+
+### Project structure
+
+```
+ui/employee-admin-portal/
+├── src/
+│   ├── components/        # Layout, navigation, and reusable UI
+│   ├── context/           # Auth & API providers
+│   ├── pages/             # Admin, employee, and shared screens
+│   ├── services/          # Mock API client (swap with real backend)
+│   └── styles/            # Global styles
+├── index.html
+├── package.json
+└── vite.config.js
+```
+
+## Customisation tips
+
+- Replace `src/services/mockApi.js` with API calls to your backend; the rest of the app consumes a clean interface via `ApiContext`.
+- Update colours, typography, or layout spacing in `src/styles/global.css` to align with your brand.
+- Extend routing in `src/App.jsx` to add more admin or employee views (e.g., knowledge base, analytics).
+
+## License
+
+This template follows the same license as the parent project. Adapt and integrate freely within your service desk solutions.

--- a/ui/employee-admin-portal/index.html
+++ b/ui/employee-admin-portal/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Employee & Admin Service Desk</title>
+  </head>
+  <body class="bg-light">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/ui/employee-admin-portal/package.json
+++ b/ui/employee-admin-portal/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "employee-admin-portal",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext js,jsx"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.11.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/ui/employee-admin-portal/src/App.jsx
+++ b/ui/employee-admin-portal/src/App.jsx
@@ -1,0 +1,55 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import AdminDashboard from './pages/admin/AdminDashboard.jsx';
+import AdminTickets from './pages/admin/AdminTickets.jsx';
+import AdminTeamManagement from './pages/admin/AdminTeamManagement.jsx';
+import EmployeeDashboard from './pages/employee/EmployeeDashboard.jsx';
+import EmployeeTickets from './pages/employee/EmployeeTickets.jsx';
+import EmployeeCreateTicket from './pages/employee/EmployeeCreateTicket.jsx';
+import AdminSignIn from './pages/shared/AdminSignIn.jsx';
+import EmployeeSignIn from './pages/shared/EmployeeSignIn.jsx';
+import AdminLayout from './components/layout/AdminLayout.jsx';
+import EmployeeLayout from './components/layout/EmployeeLayout.jsx';
+import ProtectedRoute from './components/navigation/ProtectedRoute.jsx';
+import NotFound from './pages/shared/NotFound.jsx';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/admin/auth/signin" replace />} />
+      <Route path="/admin/auth/signin" element={<AdminSignIn />} />
+      <Route path="/employee/auth/signin" element={<EmployeeSignIn />} />
+
+      <Route
+        path="/admin"
+        element={(
+          <ProtectedRoute allowedRoles={["admin"]}>
+            <AdminLayout />
+          </ProtectedRoute>
+        )}
+      >
+        <Route index element={<Navigate to="dashboard" replace />} />
+        <Route path="dashboard" element={<AdminDashboard />} />
+        <Route path="tickets" element={<AdminTickets />} />
+        <Route path="team/*" element={<AdminTeamManagement />} />
+      </Route>
+
+      <Route
+        path="/employee"
+        element={(
+          <ProtectedRoute allowedRoles={["employee"]}>
+            <EmployeeLayout />
+          </ProtectedRoute>
+        )}
+      >
+        <Route index element={<Navigate to="dashboard" replace />} />
+        <Route path="dashboard" element={<EmployeeDashboard />} />
+        <Route path="tickets" element={<EmployeeTickets />} />
+        <Route path="tickets/create" element={<EmployeeCreateTicket />} />
+      </Route>
+
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/ui/employee-admin-portal/src/components/layout/AdminLayout.jsx
+++ b/ui/employee-admin-portal/src/components/layout/AdminLayout.jsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import AdminSidebar from './AdminSidebar.jsx';
+import Topbar from './Topbar.jsx';
+import PageShell from './PageShell.jsx';
+
+function AdminLayout() {
+  return (
+    <PageShell sidebar={<AdminSidebar />}>
+      <Topbar />
+      <div className="content-wrapper">
+        <Outlet />
+      </div>
+    </PageShell>
+  );
+}
+
+export default AdminLayout;

--- a/ui/employee-admin-portal/src/components/layout/AdminSidebar.jsx
+++ b/ui/employee-admin-portal/src/components/layout/AdminSidebar.jsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext.jsx';
+import SidebarLogo from './SidebarLogo.jsx';
+
+const navItems = [
+  {
+    label: 'Dashboard',
+    icon: 'bi-speedometer2',
+    to: '/admin/dashboard'
+  },
+  {
+    label: 'All Tickets',
+    icon: 'bi-ticket-detailed',
+    to: '/admin/tickets'
+  }
+];
+
+function AdminSidebar() {
+  const { user, logout } = useAuth();
+  const [teamOpen, setTeamOpen] = useState(true);
+
+  return (
+    <div className="h-100 d-flex flex-column">
+      <SidebarLogo title="Vello Desk" subtitle="Admin" />
+      <nav className="flex-grow-1 px-3">
+        <ul className="nav flex-column gap-1">
+          {navItems.map((item) => (
+            <li key={item.label}>
+              <NavLink className="nav-link sidebar-link" to={item.to}>
+                <i className={`bi ${item.icon} me-2`}></i>
+                {item.label}
+              </NavLink>
+            </li>
+          ))}
+          <li>
+            <button
+              type="button"
+              className="nav-link sidebar-link w-100 text-start"
+              onClick={() => setTeamOpen((value) => !value)}
+            >
+              <i className="bi bi-people me-2"></i>
+              Team Manage
+              <i className={`bi bi-chevron-${teamOpen ? 'up' : 'down'} float-end`}></i>
+            </button>
+            {teamOpen && (
+              <div className="ps-4">
+                <NavLink className="nav-link sidebar-sublink" to="/admin/team/departments">
+                  Departments
+                </NavLink>
+                <NavLink className="nav-link sidebar-sublink" to="/admin/team/employees">
+                  Employees
+                </NavLink>
+              </div>
+            )}
+          </li>
+        </ul>
+      </nav>
+      <div className="px-3 py-4 border-top small text-muted">
+        <div className="d-flex align-items-center mb-3">
+          <img
+            src={user?.avatar}
+            alt={user?.name}
+            className="rounded-circle me-2"
+            width="40"
+            height="40"
+          />
+          <div>
+            <div className="fw-semibold text-dark">{user?.name}</div>
+            <div className="text-muted">Administrator</div>
+          </div>
+        </div>
+        <button type="button" className="btn btn-outline-secondary w-100" onClick={logout}>
+          <i className="bi bi-box-arrow-right me-2"></i>
+          Sign out
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default AdminSidebar;

--- a/ui/employee-admin-portal/src/components/layout/EmployeeLayout.jsx
+++ b/ui/employee-admin-portal/src/components/layout/EmployeeLayout.jsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import EmployeeSidebar from './EmployeeSidebar.jsx';
+import Topbar from './Topbar.jsx';
+import PageShell from './PageShell.jsx';
+
+function EmployeeLayout() {
+  return (
+    <PageShell sidebar={<EmployeeSidebar />}>
+      <Topbar />
+      <div className="content-wrapper">
+        <Outlet />
+      </div>
+    </PageShell>
+  );
+}
+
+export default EmployeeLayout;

--- a/ui/employee-admin-portal/src/components/layout/EmployeeSidebar.jsx
+++ b/ui/employee-admin-portal/src/components/layout/EmployeeSidebar.jsx
@@ -1,0 +1,64 @@
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext.jsx';
+import SidebarLogo from './SidebarLogo.jsx';
+
+const navItems = [
+  {
+    label: 'Dashboard',
+    icon: 'bi-speedometer2',
+    to: '/employee/dashboard'
+  },
+  {
+    label: 'All Tickets',
+    icon: 'bi-list-check',
+    to: '/employee/tickets'
+  },
+  {
+    label: 'Create Ticket',
+    icon: 'bi-plus-circle',
+    to: '/employee/tickets/create'
+  }
+];
+
+function EmployeeSidebar() {
+  const { user, logout } = useAuth();
+
+  return (
+    <div className="h-100 d-flex flex-column">
+      <SidebarLogo title="Vello Desk" subtitle="Employee" />
+      <nav className="flex-grow-1 px-3">
+        <ul className="nav flex-column gap-1">
+          {navItems.map((item) => (
+            <li key={item.label}>
+              <NavLink className="nav-link sidebar-link" to={item.to}>
+                <i className={`bi ${item.icon} me-2`}></i>
+                {item.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="px-3 py-4 border-top small text-muted">
+        <div className="d-flex align-items-center mb-3">
+          <img
+            src={user?.avatar}
+            alt={user?.name}
+            className="rounded-circle me-2"
+            width="40"
+            height="40"
+          />
+          <div>
+            <div className="fw-semibold text-dark">{user?.name}</div>
+            <div className="text-muted">Employee</div>
+          </div>
+        </div>
+        <button type="button" className="btn btn-outline-secondary w-100" onClick={logout}>
+          <i className="bi bi-box-arrow-right me-2"></i>
+          Sign out
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default EmployeeSidebar;

--- a/ui/employee-admin-portal/src/components/layout/PageContainer.jsx
+++ b/ui/employee-admin-portal/src/components/layout/PageContainer.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+function PageContainer({ title, action, children }) {
+  return (
+    <div className="p-4">
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <div>
+          <h2 className="fw-bold mb-1 text-dark">{title}</h2>
+          <p className="text-muted mb-0">Smart service desk with modern experience.</p>
+        </div>
+        {action && <div>{action}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+PageContainer.propTypes = {
+  title: PropTypes.string.isRequired,
+  action: PropTypes.node,
+  children: PropTypes.node
+};
+
+export default PageContainer;

--- a/ui/employee-admin-portal/src/components/layout/PageShell.jsx
+++ b/ui/employee-admin-portal/src/components/layout/PageShell.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+
+function PageShell({ sidebar, children }) {
+  return (
+    <div className="d-flex min-vh-100 bg-light">
+      <aside className="sidebar shadow-sm">{sidebar}</aside>
+      <main className="flex-grow-1 d-flex flex-column">
+        {children}
+      </main>
+    </div>
+  );
+}
+
+PageShell.propTypes = {
+  sidebar: PropTypes.node.isRequired,
+  children: PropTypes.node
+};
+
+export default PageShell;

--- a/ui/employee-admin-portal/src/components/layout/SidebarLogo.jsx
+++ b/ui/employee-admin-portal/src/components/layout/SidebarLogo.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+function SidebarLogo({ title, subtitle }) {
+  return (
+    <div className="px-4 py-4 border-bottom">
+      <div className="d-flex align-items-center gap-3">
+        <div className="brand-circle">
+          <i className="bi bi-lightning-charge-fill text-white"></i>
+        </div>
+        <div>
+          <h5 className="mb-0 text-white">{title}</h5>
+          <small className="text-white-50 text-uppercase">{subtitle}</small>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+SidebarLogo.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired
+};
+
+export default SidebarLogo;

--- a/ui/employee-admin-portal/src/components/layout/Topbar.jsx
+++ b/ui/employee-admin-portal/src/components/layout/Topbar.jsx
@@ -1,0 +1,40 @@
+import { useAuth } from '../../context/AuthContext.jsx';
+
+function Topbar() {
+  const { user } = useAuth();
+
+  return (
+    <header className="topbar d-flex align-items-center justify-content-between px-4 py-3 border-bottom bg-white">
+      <div>
+        <h6 className="text-uppercase text-muted mb-0">Service Desk Portal</h6>
+        <h3 className="fw-bold mb-0">Welcome back, {user?.name?.split(' ')[0]}!</h3>
+      </div>
+      <div className="d-flex align-items-center gap-3">
+        <button type="button" className="btn btn-outline-secondary btn-sm">
+          <i className="bi bi-search"></i>
+        </button>
+        <button type="button" className="btn btn-outline-secondary btn-sm position-relative">
+          <i className="bi bi-bell"></i>
+          <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+            3
+          </span>
+        </button>
+        <div className="d-flex align-items-center">
+          <img
+            src={user?.avatar}
+            alt={user?.name}
+            className="rounded-circle me-2"
+            width="40"
+            height="40"
+          />
+          <div className="text-end">
+            <div className="fw-semibold text-dark">{user?.name}</div>
+            <small className="text-muted text-capitalize">{user?.role}</small>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export default Topbar;

--- a/ui/employee-admin-portal/src/components/navigation/ProtectedRoute.jsx
+++ b/ui/employee-admin-portal/src/components/navigation/ProtectedRoute.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+function ProtectedRoute({ children, allowedRoles }) {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="d-flex align-items-center justify-content-center vh-100 bg-light">
+        <div className="spinner-border text-primary" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/admin/auth/signin" state={{ from: location }} replace />;
+  }
+
+  if (allowedRoles && !allowedRoles.includes(user.role)) {
+    const redirectTo = user.role === 'admin' ? '/admin/dashboard' : '/employee/dashboard';
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return children;
+}
+
+ProtectedRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+  allowedRoles: PropTypes.arrayOf(PropTypes.string)
+};
+
+export default ProtectedRoute;

--- a/ui/employee-admin-portal/src/components/ui/StatCard.jsx
+++ b/ui/employee-admin-portal/src/components/ui/StatCard.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+
+function StatCard({ title, value, icon, variant = 'primary', subtitle }) {
+  return (
+    <div className={`card border-0 shadow-sm stat-card bg-${variant} text-white`}>
+      <div className="card-body d-flex align-items-center justify-content-between">
+        <div>
+          <h6 className="text-uppercase text-white-50 mb-1">{title}</h6>
+          <h3 className="fw-bold mb-0">{value}</h3>
+          {subtitle && <small className="text-white-50">{subtitle}</small>}
+        </div>
+        {icon && (
+          <div className="icon-wrapper">
+            <i className={`bi ${icon}`}></i>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+StatCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  icon: PropTypes.string,
+  variant: PropTypes.string,
+  subtitle: PropTypes.string
+};
+
+export default StatCard;

--- a/ui/employee-admin-portal/src/components/ui/TicketStatusBadge.jsx
+++ b/ui/employee-admin-portal/src/components/ui/TicketStatusBadge.jsx
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+
+function TicketStatusBadge({ status }) {
+  const variant = statusToVariant(status);
+  return <span className={`badge rounded-pill bg-${variant}`}>{status}</span>;
+}
+
+function statusToVariant(status) {
+  switch (status) {
+    case 'Open':
+      return 'primary';
+    case 'In Progress':
+      return 'info';
+    case 'Closed':
+      return 'success';
+    default:
+      return 'secondary';
+  }
+}
+
+TicketStatusBadge.propTypes = {
+  status: PropTypes.string.isRequired
+};
+
+export default TicketStatusBadge;

--- a/ui/employee-admin-portal/src/components/ui/TicketTable.jsx
+++ b/ui/employee-admin-portal/src/components/ui/TicketTable.jsx
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import TicketStatusBadge from './TicketStatusBadge.jsx';
+
+function TicketTable({ tickets }) {
+  return (
+    <div className="table-responsive card border-0 shadow-sm">
+      <table className="table align-middle mb-0">
+        <thead className="table-light">
+          <tr>
+            <th scope="col">Ticket ID</th>
+            <th scope="col">Subject</th>
+            <th scope="col">Requester</th>
+            <th scope="col">Department</th>
+            <th scope="col">Priority</th>
+            <th scope="col">Status</th>
+            <th scope="col" className="text-end">
+              Created
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {tickets.map((ticket) => (
+            <tr key={ticket.id}>
+              <td className="fw-semibold text-dark">{ticket.id}</td>
+              <td>{ticket.subject}</td>
+              <td>{ticket.requester}</td>
+              <td>{ticket.department}</td>
+              <td>
+                <span className={`badge bg-${priorityToColor(ticket.priority)}`}>{ticket.priority}</span>
+              </td>
+              <td>
+                <TicketStatusBadge status={ticket.status} />
+              </td>
+              <td className="text-end text-muted">{ticket.createdAt}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function priorityToColor(priority) {
+  switch (priority) {
+    case 'High':
+      return 'danger';
+    case 'Medium':
+      return 'warning';
+    default:
+      return 'secondary';
+  }
+}
+
+TicketTable.propTypes = {
+  tickets: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      subject: PropTypes.string.isRequired,
+      requester: PropTypes.string.isRequired,
+      department: PropTypes.string.isRequired,
+      priority: PropTypes.string.isRequired,
+      status: PropTypes.string.isRequired,
+      createdAt: PropTypes.string.isRequired
+    })
+  ).isRequired
+};
+
+export default TicketTable;

--- a/ui/employee-admin-portal/src/context/ApiContext.jsx
+++ b/ui/employee-admin-portal/src/context/ApiContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useMemo } from 'react';
+import { createApiClient } from '../services/mockApi.js';
+
+const ApiContext = createContext();
+
+export function ApiProvider({ children }) {
+  const client = useMemo(() => createApiClient(), []);
+
+  const value = useMemo(
+    () => ({
+      authApi: client.auth,
+      ticketApi: client.tickets,
+      teamApi: client.team,
+      dashboardApi: client.dashboard
+    }),
+    [client]
+  );
+
+  return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;
+}
+
+export function useApi() {
+  const context = useContext(ApiContext);
+  if (!context) {
+    throw new Error('useApi must be used within an ApiProvider');
+  }
+  return context;
+}

--- a/ui/employee-admin-portal/src/context/AuthContext.jsx
+++ b/ui/employee-admin-portal/src/context/AuthContext.jsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useApi } from './ApiContext.jsx';
+
+const AuthContext = createContext();
+
+const STORAGE_KEY = 'service-desk-auth';
+
+export function AuthProvider({ children }) {
+  const { authApi } = useApi();
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      setUser(JSON.parse(saved));
+    }
+    setLoading(false);
+  }, []);
+
+  const login = async (credentials) => {
+    const profile = await authApi.signIn(credentials);
+    setUser(profile);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+    return profile;
+  };
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem(STORAGE_KEY);
+  };
+
+  const value = useMemo(
+    () => ({
+      user,
+      loading,
+      login,
+      logout
+    }),
+    [user, loading]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/ui/employee-admin-portal/src/main.jsx
+++ b/ui/employee-admin-portal/src/main.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
+import { ApiProvider } from './context/ApiContext.jsx';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <ApiProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ApiProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/ui/employee-admin-portal/src/pages/admin/AdminDashboard.jsx
+++ b/ui/employee-admin-portal/src/pages/admin/AdminDashboard.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import PageContainer from '../../components/layout/PageContainer.jsx';
+import StatCard from '../../components/ui/StatCard.jsx';
+import TicketTable from '../../components/ui/TicketTable.jsx';
+import { useApi } from '../../context/ApiContext.jsx';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+function AdminDashboard() {
+  const { dashboardApi, ticketApi } = useApi();
+  const { user } = useAuth();
+  const [summary, setSummary] = useState(null);
+  const [tickets, setTickets] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadData() {
+      setLoading(true);
+      const [summaryResponse, ticketResponse] = await Promise.all([
+        dashboardApi.summary(user.role),
+        ticketApi.list()
+      ]);
+      setSummary(summaryResponse);
+      setTickets(ticketResponse);
+      setLoading(false);
+    }
+
+    loadData();
+  }, [dashboardApi, ticketApi, user.role]);
+
+  return (
+    <PageContainer
+      title="Executive Overview"
+      action={
+        <button type="button" className="btn btn-primary">
+          <i className="bi bi-plus-circle me-2"></i>
+          New Ticket
+        </button>
+      }
+    >
+      {loading ? (
+        <div className="text-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="row g-4 mb-4">
+            <div className="col-md-3">
+              <StatCard
+                title="Open Tickets"
+                value={summary.openTickets}
+                icon="bi-life-preserver"
+                variant="primary"
+                subtitle="Actively being worked on"
+              />
+            </div>
+            <div className="col-md-3">
+              <StatCard
+                title="Closed Tickets"
+                value={summary.closedTickets}
+                icon="bi-check-circle"
+                variant="success"
+                subtitle="Resolved this month"
+              />
+            </div>
+            <div className="col-md-3">
+              <StatCard
+                title="Avg. Response"
+                value={summary.avgResponse}
+                icon="bi-stopwatch"
+                variant="warning"
+                subtitle="Response time"
+              />
+            </div>
+            <div className="col-md-3">
+              <StatCard
+                title="CSAT"
+                value={`${summary.satisfaction}%`}
+                icon="bi-emoji-smile"
+                variant="info"
+                subtitle="Customer satisfaction"
+              />
+            </div>
+          </div>
+
+          <div className="row g-4">
+            <div className="col-xl-8">
+              <TicketTable tickets={tickets} />
+            </div>
+            <div className="col-xl-4">
+              <div className="card border-0 shadow-sm mb-4">
+                <div className="card-body">
+                  <h5 className="card-title">Team Snapshot</h5>
+                  <p className="text-muted">
+                    Track your operational health and ensure the right people are assigned to the right
+                    tickets.
+                  </p>
+                  <ul className="list-group list-group-flush">
+                    <li className="list-group-item d-flex justify-content-between align-items-center">
+                      Total Squads <span className="badge bg-primary rounded-pill">{summary.teamCount}</span>
+                    </li>
+                    <li className="list-group-item d-flex justify-content-between align-items-center">
+                      Total Members{' '}
+                      <span className="badge bg-secondary rounded-pill">{summary.employeeCount}</span>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div className="card border-0 shadow-sm">
+                <div className="card-body">
+                  <h5 className="card-title">Announcements</h5>
+                  <div className="d-flex align-items-start gap-3">
+                    <div className="badge bg-danger rounded-pill">Hot</div>
+                    <div>
+                      <h6 className="mb-1">On-call changes this weekend</h6>
+                      <p className="text-muted mb-0">
+                        Infrastructure team will cover Sev-1 incidents. Update the schedule accordingly.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </PageContainer>
+  );
+}
+
+export default AdminDashboard;

--- a/ui/employee-admin-portal/src/pages/admin/AdminTeamManagement.jsx
+++ b/ui/employee-admin-portal/src/pages/admin/AdminTeamManagement.jsx
@@ -1,0 +1,164 @@
+import PropTypes from 'prop-types';
+import { useEffect, useMemo, useState } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import PageContainer from '../../components/layout/PageContainer.jsx';
+import { useApi } from '../../context/ApiContext.jsx';
+
+function AdminTeamManagement() {
+  const { teamApi } = useApi();
+  const [departments, setDepartments] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadDepartments() {
+      setLoading(true);
+      const response = await teamApi.listDepartments();
+      setDepartments(response);
+      setLoading(false);
+    }
+
+    loadDepartments();
+  }, [teamApi]);
+
+  return (
+    <Routes>
+      <Route index element={<Navigate to="departments" replace />} />
+      <Route
+        path="departments"
+        element={<DepartmentsView loading={loading} departments={departments} />}
+      />
+      <Route
+        path="employees"
+        element={<EmployeesView loading={loading} departments={departments} />}
+      />
+      <Route path="*" element={<Navigate to="departments" replace />} />
+    </Routes>
+  );
+}
+
+function DepartmentsView({ loading, departments }) {
+  return (
+    <PageContainer title="Team Management">
+      {loading ? (
+        <div className="text-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </div>
+      ) : (
+        <div className="accordion" id="departmentAccordion">
+          {departments.map((dept, index) => (
+            <div className="accordion-item border-0 shadow-sm mb-3" key={dept.id}>
+              <h2 className="accordion-header" id={`heading-${dept.id}`}>
+                <button
+                  className={`accordion-button ${index !== 0 ? 'collapsed' : ''}`}
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target={`#collapse-${dept.id}`}
+                  aria-expanded={index === 0}
+                  aria-controls={`collapse-${dept.id}`}
+                >
+                  <div>
+                    <h5 className="mb-1">{dept.name}</h5>
+                    <small className="text-muted">Department Lead: {dept.lead}</small>
+                  </div>
+                </button>
+              </h2>
+              <div
+                id={`collapse-${dept.id}`}
+                className={`accordion-collapse collapse ${index === 0 ? 'show' : ''}`}
+                aria-labelledby={`heading-${dept.id}`}
+                data-bs-parent="#departmentAccordion"
+              >
+                <div className="accordion-body">
+                  <div className="row g-4">
+                    {dept.subDepartments.map((sub) => (
+                      <div className="col-md-6" key={sub.id}>
+                        <div className="card border-0 bg-light shadow-sm h-100">
+                          <div className="card-body">
+                            <h6 className="fw-semibold">{sub.name}</h6>
+                            <ul className="list-unstyled mb-0 small text-muted">
+                              {sub.employees.map((employee) => (
+                                <li key={employee} className="d-flex align-items-center gap-2">
+                                  <i className="bi bi-person-circle text-primary"></i>
+                                  {employee}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </PageContainer>
+  );
+}
+
+function EmployeesView({ loading, departments }) {
+  const employees = useMemo(
+    () =>
+      departments.flatMap((dept) =>
+        dept.subDepartments.flatMap((sub) =>
+          sub.employees.map((name) => ({
+            department: dept.name,
+            subDepartment: sub.name,
+            name
+          }))
+        )
+      ),
+    [departments]
+  );
+
+  return (
+    <PageContainer title="Employee Directory">
+      {loading ? (
+        <div className="text-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </div>
+      ) : (
+        <div className="card border-0 shadow-sm">
+          <div className="table-responsive">
+            <table className="table align-middle mb-0">
+              <thead className="table-light">
+                <tr>
+                  <th scope="col">Name</th>
+                  <th scope="col">Department</th>
+                  <th scope="col">Squad</th>
+                </tr>
+              </thead>
+              <tbody>
+                {employees.map((employee) => (
+                  <tr key={`${employee.name}-${employee.subDepartment}`}>
+                    <td className="fw-semibold text-dark">{employee.name}</td>
+                    <td>{employee.department}</td>
+                    <td>{employee.subDepartment}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </PageContainer>
+  );
+}
+
+DepartmentsView.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  departments: PropTypes.arrayOf(PropTypes.object).isRequired
+};
+
+EmployeesView.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  departments: PropTypes.arrayOf(PropTypes.object).isRequired
+};
+
+export default AdminTeamManagement;

--- a/ui/employee-admin-portal/src/pages/admin/AdminTickets.jsx
+++ b/ui/employee-admin-portal/src/pages/admin/AdminTickets.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import PageContainer from '../../components/layout/PageContainer.jsx';
+import TicketTable from '../../components/ui/TicketTable.jsx';
+import { useApi } from '../../context/ApiContext.jsx';
+
+function AdminTickets() {
+  const { ticketApi } = useApi();
+  const [tickets, setTickets] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadTickets() {
+      setLoading(true);
+      const response = await ticketApi.list();
+      setTickets(response);
+      setLoading(false);
+    }
+
+    loadTickets();
+  }, [ticketApi]);
+
+  return (
+    <PageContainer
+      title="All Tickets"
+      action={
+        <button type="button" className="btn btn-outline-primary">
+          <i className="bi bi-download me-2"></i>
+          Export CSV
+        </button>
+      }
+    >
+      {loading ? (
+        <div className="text-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </div>
+      ) : (
+        <TicketTable tickets={tickets} />
+      )}
+    </PageContainer>
+  );
+}
+
+export default AdminTickets;

--- a/ui/employee-admin-portal/src/pages/employee/EmployeeCreateTicket.jsx
+++ b/ui/employee-admin-portal/src/pages/employee/EmployeeCreateTicket.jsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import PageContainer from '../../components/layout/PageContainer.jsx';
+import { useApi } from '../../context/ApiContext.jsx';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+const initialForm = {
+  subject: '',
+  description: '',
+  department: 'IT Support',
+  priority: 'Medium'
+};
+
+function EmployeeCreateTicket() {
+  const { ticketApi } = useApi();
+  const { user } = useAuth();
+  const [form, setForm] = useState(initialForm);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(null);
+  const [error, setError] = useState(null);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const ticket = await ticketApi.create({
+        ...form,
+        requester: user.name,
+        status: 'Open'
+      });
+      setSuccess(ticket);
+      setForm(initialForm);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <PageContainer title="Create Ticket">
+      <div className="row">
+        <div className="col-lg-8">
+          <div className="card border-0 shadow-sm">
+            <div className="card-body">
+              <form onSubmit={handleSubmit} className="row g-3">
+                <div className="col-12">
+                  <label htmlFor="subject" className="form-label fw-semibold">
+                    Subject
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control"
+                    id="subject"
+                    name="subject"
+                    placeholder="Describe your issue in a sentence"
+                    value={form.subject}
+                    onChange={handleChange}
+                    required
+                  />
+                </div>
+                <div className="col-12">
+                  <label htmlFor="description" className="form-label fw-semibold">
+                    Description
+                  </label>
+                  <textarea
+                    className="form-control"
+                    id="description"
+                    name="description"
+                    rows="4"
+                    placeholder="Share relevant details, logs, or steps to reproduce."
+                    value={form.description}
+                    onChange={handleChange}
+                    required
+                  ></textarea>
+                </div>
+                <div className="col-md-6">
+                  <label htmlFor="department" className="form-label fw-semibold">
+                    Department
+                  </label>
+                  <select
+                    id="department"
+                    name="department"
+                    className="form-select"
+                    value={form.department}
+                    onChange={handleChange}
+                  >
+                    <option>IT Support</option>
+                    <option>Infrastructure</option>
+                    <option>Human Resources</option>
+                    <option>Finance</option>
+                  </select>
+                </div>
+                <div className="col-md-6">
+                  <label htmlFor="priority" className="form-label fw-semibold">
+                    Priority
+                  </label>
+                  <select
+                    id="priority"
+                    name="priority"
+                    className="form-select"
+                    value={form.priority}
+                    onChange={handleChange}
+                  >
+                    <option>Low</option>
+                    <option>Medium</option>
+                    <option>High</option>
+                  </select>
+                </div>
+                <div className="col-12 d-flex justify-content-end gap-2">
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                    onClick={() => setForm(initialForm)}
+                    disabled={submitting}
+                  >
+                    Reset
+                  </button>
+                  <button type="submit" className="btn btn-primary" disabled={submitting}>
+                    {submitting ? 'Submitting…' : 'Submit Ticket'}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div className="col-lg-4">
+          <div className="card border-0 shadow-sm mb-3">
+            <div className="card-body">
+              <h5 className="card-title">Need help writing a good ticket?</h5>
+              <ul className="list-unstyled text-muted small mb-0">
+                <li className="d-flex gap-2 mb-2">
+                  <i className="bi bi-hash text-primary"></i>
+                  Provide clear subject with asset ID or error code.
+                </li>
+                <li className="d-flex gap-2 mb-2">
+                  <i className="bi bi-image text-success"></i>
+                  Attach visuals when possible to speed up investigation.
+                </li>
+                <li className="d-flex gap-2">
+                  <i className="bi bi-clock-history text-warning"></i>
+                  Mention impact and urgency for better triage.
+                </li>
+              </ul>
+            </div>
+          </div>
+          {success && (
+            <div className="alert alert-success shadow-sm" role="alert">
+              Ticket {success.id} created successfully! Our team will reach out shortly.
+            </div>
+          )}
+          {error && (
+            <div className="alert alert-danger shadow-sm" role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
+    </PageContainer>
+  );
+}
+
+export default EmployeeCreateTicket;

--- a/ui/employee-admin-portal/src/pages/employee/EmployeeDashboard.jsx
+++ b/ui/employee-admin-portal/src/pages/employee/EmployeeDashboard.jsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import PageContainer from '../../components/layout/PageContainer.jsx';
+import StatCard from '../../components/ui/StatCard.jsx';
+import TicketTable from '../../components/ui/TicketTable.jsx';
+import { useApi } from '../../context/ApiContext.jsx';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+function EmployeeDashboard() {
+  const { dashboardApi, ticketApi } = useApi();
+  const { user } = useAuth();
+  const [summary, setSummary] = useState(null);
+  const [tickets, setTickets] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadData() {
+      setLoading(true);
+      const [summaryResponse, ticketResponse] = await Promise.all([
+        dashboardApi.summary(user.role),
+        ticketApi.listByUser(user.role)
+      ]);
+      setSummary(summaryResponse);
+      setTickets(ticketResponse);
+      setLoading(false);
+    }
+
+    loadData();
+  }, [dashboardApi, ticketApi, user.role]);
+
+  return (
+    <PageContainer title="My Workspace">
+      {loading ? (
+        <div className="text-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="row g-4 mb-4">
+            <div className="col-md-4">
+              <StatCard
+                title="My Open Tickets"
+                value={tickets.filter((ticket) => ticket.status !== 'Closed').length}
+                icon="bi-envelope-open"
+                variant="primary"
+              />
+            </div>
+            <div className="col-md-4">
+              <StatCard
+                title="Resolved"
+                value={tickets.filter((ticket) => ticket.status === 'Closed').length}
+                icon="bi-check2-circle"
+                variant="success"
+              />
+            </div>
+            <div className="col-md-4">
+              <StatCard
+                title="Average SLA"
+                value={summary.avgResponse}
+                icon="bi-lightning"
+                variant="warning"
+              />
+            </div>
+          </div>
+
+          <div className="row g-4">
+            <div className="col-lg-8">
+              <TicketTable tickets={tickets} />
+            </div>
+            <div className="col-lg-4">
+              <div className="card border-0 shadow-sm">
+                <div className="card-body">
+                  <h5 className="card-title">Quick Tips</h5>
+                  <ul className="list-unstyled text-muted small mb-0">
+                    <li className="d-flex gap-2 mb-2">
+                      <i className="bi bi-lightbulb text-warning"></i>
+                      Attach screenshots when reporting UI issues.
+                    </li>
+                    <li className="d-flex gap-2 mb-2">
+                      <i className="bi bi-clock-history text-primary"></i>
+                      Track progress in real-time from the tickets tab.
+                    </li>
+                    <li className="d-flex gap-2">
+                      <i className="bi bi-chat-dots text-success"></i>
+                      Collaborate with the assigned agent via comments.
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </PageContainer>
+  );
+}
+
+export default EmployeeDashboard;

--- a/ui/employee-admin-portal/src/pages/employee/EmployeeTickets.jsx
+++ b/ui/employee-admin-portal/src/pages/employee/EmployeeTickets.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import PageContainer from '../../components/layout/PageContainer.jsx';
+import TicketTable from '../../components/ui/TicketTable.jsx';
+import { useApi } from '../../context/ApiContext.jsx';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+function EmployeeTickets() {
+  const { ticketApi } = useApi();
+  const { user } = useAuth();
+  const [tickets, setTickets] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadTickets() {
+      setLoading(true);
+      const response = await ticketApi.listByUser(user.role);
+      setTickets(response);
+      setLoading(false);
+    }
+
+    loadTickets();
+  }, [ticketApi, user.role]);
+
+  return (
+    <PageContainer
+      title="All Tickets"
+      action={
+        <button type="button" className="btn btn-primary">
+          <i className="bi bi-plus-circle me-2"></i>
+          Create Ticket
+        </button>
+      }
+    >
+      {loading ? (
+        <div className="text-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </div>
+      ) : (
+        <TicketTable tickets={tickets} />
+      )}
+    </PageContainer>
+  );
+}
+
+export default EmployeeTickets;

--- a/ui/employee-admin-portal/src/pages/shared/AdminSignIn.jsx
+++ b/ui/employee-admin-portal/src/pages/shared/AdminSignIn.jsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import SignInTemplate from './SignInTemplate.jsx';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+function AdminSignIn() {
+  const { login, logout } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const credentials = {
+      email: formData.get('email'),
+      password: formData.get('password')
+    };
+
+    try {
+      setLoading(true);
+      setError(null);
+      const profile = await login(credentials);
+      if (profile.role !== 'admin') {
+        setError('You do not have administrator access.');
+        logout();
+        return;
+      }
+      const redirectTo = location.state?.from?.pathname || '/admin/dashboard';
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SignInTemplate
+      title="Admin Control Center"
+      subtitle="Monitor tickets, manage teams, and configure your service desk."
+      onSubmit={handleSubmit}
+      loading={loading}
+      error={error}
+    />
+  );
+}
+
+export default AdminSignIn;

--- a/ui/employee-admin-portal/src/pages/shared/EmployeeSignIn.jsx
+++ b/ui/employee-admin-portal/src/pages/shared/EmployeeSignIn.jsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import SignInTemplate from './SignInTemplate.jsx';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+function EmployeeSignIn() {
+  const { login, logout } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const credentials = {
+      email: formData.get('email'),
+      password: formData.get('password')
+    };
+
+    try {
+      setLoading(true);
+      setError(null);
+      const profile = await login(credentials);
+      if (profile.role !== 'employee') {
+        setError('This portal is for employees only. Please sign in using the admin portal.');
+        logout();
+        return;
+      }
+      const redirectTo = location.state?.from?.pathname || '/employee/dashboard';
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SignInTemplate
+      title="Employee Service Desk"
+      subtitle="Track progress, raise new requests, and stay aligned with your support team."
+      onSubmit={handleSubmit}
+      loading={loading}
+      error={error}
+    />
+  );
+}
+
+export default EmployeeSignIn;

--- a/ui/employee-admin-portal/src/pages/shared/NotFound.jsx
+++ b/ui/employee-admin-portal/src/pages/shared/NotFound.jsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+
+function NotFound() {
+  return (
+    <div className="d-flex align-items-center justify-content-center vh-100 bg-light">
+      <div className="text-center">
+        <div className="display-1 fw-bold text-primary">404</div>
+        <p className="lead text-muted">The page you were looking for could not be found.</p>
+        <Link to="/admin/auth/signin" className="btn btn-primary">
+          Back to Portal
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/ui/employee-admin-portal/src/pages/shared/SignInTemplate.jsx
+++ b/ui/employee-admin-portal/src/pages/shared/SignInTemplate.jsx
@@ -1,0 +1,75 @@
+import PropTypes from 'prop-types';
+
+function SignInTemplate({ title, subtitle, onSubmit, loading, error }) {
+  return (
+    <div className="auth-page d-flex align-items-center justify-content-center min-vh-100 bg-gradient">
+      <div className="card shadow-lg border-0 auth-card">
+        <div className="row g-0">
+          <div className="col-lg-6 d-none d-lg-block auth-illustration"></div>
+          <div className="col-lg-6">
+            <div className="p-5">
+              <div className="mb-4 text-center">
+                <div className="brand-circle mx-auto mb-3">
+                  <i className="bi bi-lightning-charge-fill text-white"></i>
+                </div>
+                <h2 className="fw-bold">{title}</h2>
+                <p className="text-muted">{subtitle}</p>
+              </div>
+              <form className="needs-validation" onSubmit={onSubmit} noValidate>
+                <div className="mb-3">
+                  <label htmlFor="email" className="form-label fw-semibold">
+                    Email address
+                  </label>
+                  <input
+                    type="email"
+                    className="form-control form-control-lg"
+                    id="email"
+                    name="email"
+                    placeholder="you@example.com"
+                    required
+                  />
+                </div>
+                <div className="mb-3">
+                  <label htmlFor="password" className="form-label fw-semibold">
+                    Password
+                  </label>
+                  <input
+                    type="password"
+                    className="form-control form-control-lg"
+                    id="password"
+                    name="password"
+                    placeholder="Enter your password"
+                    required
+                  />
+                </div>
+                {error && (
+                  <div className="alert alert-danger" role="alert">
+                    {error}
+                  </div>
+                )}
+                <div className="d-grid gap-2">
+                  <button type="submit" className="btn btn-primary btn-lg" disabled={loading}>
+                    {loading ? 'Signing in…' : 'Sign In'}
+                  </button>
+                </div>
+              </form>
+              <div className="mt-4 text-muted small">
+                Use demo credentials: admin@desk.com / admin123 or employee@desk.com / employee123
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+SignInTemplate.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  error: PropTypes.string
+};
+
+export default SignInTemplate;

--- a/ui/employee-admin-portal/src/services/mockApi.js
+++ b/ui/employee-admin-portal/src/services/mockApi.js
@@ -1,0 +1,156 @@
+const delay = (result, time = 400) =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(result), time);
+  });
+
+const users = [
+  {
+    id: 'admin-1',
+    email: 'admin@desk.com',
+    password: 'admin123',
+    role: 'admin',
+    name: 'Aisha Khan',
+    avatar: 'https://i.pravatar.cc/150?img=12'
+  },
+  {
+    id: 'employee-1',
+    email: 'employee@desk.com',
+    password: 'employee123',
+    role: 'employee',
+    name: 'Ravi Patel',
+    avatar: 'https://i.pravatar.cc/150?img=33'
+  }
+];
+
+const tickets = [
+  {
+    id: 'TCK-1001',
+    subject: 'Laptop screen flickering',
+    requester: 'Ravi Patel',
+    department: 'IT Support',
+    status: 'In Progress',
+    priority: 'High',
+    createdAt: '2024-03-01'
+  },
+  {
+    id: 'TCK-1002',
+    subject: 'VPN access request',
+    requester: 'Aisha Khan',
+    department: 'Infrastructure',
+    status: 'Open',
+    priority: 'Medium',
+    createdAt: '2024-03-02'
+  },
+  {
+    id: 'TCK-1003',
+    subject: 'New employee onboarding',
+    requester: 'HR Team',
+    department: 'Human Resources',
+    status: 'Closed',
+    priority: 'Low',
+    createdAt: '2024-02-25'
+  }
+];
+
+const departments = [
+  {
+    id: 'dept-it',
+    name: 'Information Technology',
+    lead: 'Rahul Verma',
+    subDepartments: [
+      {
+        id: 'dept-it-support',
+        name: 'IT Support',
+        employees: ['Ravi Patel', 'Aditi Sharma']
+      },
+      {
+        id: 'dept-it-infra',
+        name: 'Infrastructure',
+        employees: ['Sanjay Kumar', 'Priya Nair']
+      }
+    ]
+  },
+  {
+    id: 'dept-hr',
+    name: 'Human Resources',
+    lead: 'Sneha Kapoor',
+    subDepartments: [
+      {
+        id: 'dept-hr-recruitment',
+        name: 'Recruitment',
+        employees: ['Anjali Menon', 'Rohit Singh']
+      },
+      {
+        id: 'dept-hr-payroll',
+        name: 'Payroll',
+        employees: ['Kiran Rao']
+      }
+    ]
+  }
+];
+
+export function createApiClient() {
+  return {
+    auth: {
+      async signIn({ email, password }) {
+        const user = users.find((item) => item.email === email && item.password === password);
+        if (!user) {
+          throw new Error('Invalid credentials. Try admin@desk.com or employee@desk.com');
+        }
+        const { password: _password, ...profile } = user;
+        return delay(profile);
+      }
+    },
+    tickets: {
+      async list() {
+        return delay([...tickets]);
+      },
+      async listByUser(role) {
+        if (role === 'admin') {
+          return delay([...tickets]);
+        }
+        return delay(tickets.filter((ticket) => ticket.requester === 'Ravi Patel'));
+      },
+      async create(ticket) {
+        const newTicket = {
+          ...ticket,
+          id: `TCK-${Math.floor(Math.random() * 9000) + 1000}`,
+          createdAt: new Date().toISOString().split('T')[0]
+        };
+        tickets.push(newTicket);
+        return delay(newTicket);
+      }
+    },
+    team: {
+      async listDepartments() {
+        return delay([...departments]);
+      }
+    },
+    dashboard: {
+      async summary(role) {
+        const base = {
+          openTickets: tickets.filter((ticket) => ticket.status !== 'Closed').length,
+          closedTickets: tickets.filter((ticket) => ticket.status === 'Closed').length,
+          avgResponse: '3h 45m',
+          satisfaction: 92
+        };
+        if (role === 'admin') {
+          return delay({
+            ...base,
+            teamCount: departments.reduce((count, dept) => count + dept.subDepartments.length, 0),
+            employeeCount: departments.reduce(
+              (count, dept) =>
+                count + dept.subDepartments.reduce((sum, sub) => sum + sub.employees.length, 0),
+              0
+            )
+          });
+        }
+        return delay({
+          ...base,
+          teamCount: 2,
+          employeeCount: 12
+        });
+      }
+    }
+  };
+}

--- a/ui/employee-admin-portal/src/styles/global.css
+++ b/ui/employee-admin-portal/src/styles/global.css
@@ -1,0 +1,128 @@
+:root {
+  --sidebar-width: 260px;
+  --brand-gradient: linear-gradient(135deg, #5b3cc4 0%, #f25f5c 100%);
+}
+
+body {
+  font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f5f6fb;
+  color: #212529;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--brand-gradient);
+  color: #fff;
+  position: sticky;
+  top: 0;
+}
+
+.sidebar-link {
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+}
+
+.sidebar-link:hover,
+.sidebar-link.active {
+  color: #fff;
+  background-color: rgba(255, 255, 255, 0.18);
+}
+
+.sidebar-sublink {
+  color: rgba(255, 255, 255, 0.75);
+  padding: 0.5rem 0.75rem;
+  display: block;
+  border-radius: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.sidebar-sublink.active,
+.sidebar-sublink:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+.brand-circle {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+}
+
+.topbar h3 {
+  color: #2a2f45;
+}
+
+.content-wrapper {
+  background-color: #f5f6fb;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.card-title {
+  font-weight: 600;
+  color: #2a2f45;
+}
+
+.stat-card .icon-wrapper {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  background-color: rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+}
+
+.auth-page {
+  background: radial-gradient(circle at top left, #5b3cc4, #2a2f45 60%);
+  padding: 2rem;
+}
+
+.auth-card {
+  max-width: 920px;
+  width: 100%;
+  border-radius: 1.5rem;
+  overflow: hidden;
+}
+
+.auth-illustration {
+  background: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=870&q=80')
+    center/cover no-repeat;
+}
+
+.bg-gradient {
+  background: radial-gradient(circle at top left, #5b3cc4, #2a2f45 60%);
+}
+
+.table > :not(caption) > * > * {
+  padding: 1rem 1.5rem;
+}
+
+.nav-link.sidebar-link:focus {
+  box-shadow: none;
+}
+
+button.nav-link.sidebar-link {
+  background: transparent;
+  border: none;
+}
+
+@media (max-width: 992px) {
+  .sidebar {
+    display: none;
+  }
+
+  .content-wrapper {
+    padding-bottom: 2rem;
+  }
+}

--- a/ui/employee-admin-portal/vite.config.js
+++ b/ui/employee-admin-portal/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- create a Vite + React + JavaScript workspace under `ui/employee-admin-portal` for a dual admin and employee service desk experience
- implement role-aware routing, authentication context, and mock API clients for dashboards, tickets, and team management views
- style the UI with Bootstrap 5, Bootstrap Icons, and custom CSS including sign-in flows, sidebars, dashboards, and ticket creation workflows

## Testing
- `npm install` *(fails: registry returned 403 for @vitejs/plugin-react in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd02c289b08323b05e559d93c875a0